### PR TITLE
Rework build script to run as a docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM debian:stable-slim
+FROM ubuntu:latest
 
-RUN apt-get update && apt-get -uy upgrade
-RUN apt-get -y install ca-certificates && update-ca-certificates
+RUN apt-get update && \
+    apt-get -uy upgrade && \
+    apt-get install -y ca-certificates software-properties-common gpg && \
+    add-apt-repository ppa:longsleep/golang-backports && \
+    apt-get update && \
+    update-ca-certificates
+RUN apt-get -y install ed git golang-go make
 
-ADD coredns /coredns
+ADD build.sh /
+RUN chmod 755 ./build.sh && ./build.sh
+
+FROM scratch
+COPY --from=0 /etc/ssl/certs /etc/ssl/certs
+COPY --from=0 /coredns /usr/local/bin
 
 EXPOSE 53 53/udp
 EXPOSE 853
 EXPOSE 443
-ENTRYPOINT ["/coredns", "-conf", "/etc/coredns/Corefile"]
+ENTRYPOINT ["coredns"]


### PR DESCRIPTION
This PR reconfigures things so that build.sh can run inside docker, and will produce a minimal Docker build of coredns with the plugin. This makes it possible for us to set up an automated build on dockerhub.